### PR TITLE
hook up `slackclient` send a message on slack using gh-slack

### DIFF
--- a/cmd/gh-slack/cmd/read.go
+++ b/cmd/gh-slack/cmd/read.go
@@ -23,6 +23,8 @@ var readCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return readSlack(args)
 	},
+	Example: `  gh-slack read <slack-permalink>
+  gh-slack read -i <issue-url> <slack-permalink>`,
 }
 
 var (
@@ -57,7 +59,6 @@ var opts struct {
 		Start string
 	}
 	Limit   int
-	Verbose bool
 	Version bool
 	Details bool
 	Issue   string
@@ -65,7 +66,6 @@ var opts struct {
 
 func init() {
 	readCmd.Flags().IntVarP(&opts.Limit, "limit", "l", 20, "Number of _channel_ messages to be fetched after the starting message (all thread messages are fetched)")
-	// readCmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Show verbose debug information")
 	readCmd.Flags().BoolVar(&opts.Version, "version", false, "Output version information")
 	readCmd.Flags().BoolVarP(&opts.Details, "details", "d", false, "Wrap the markdown output in HTML <details> tags")
 	readCmd.Flags().StringVarP(&opts.Issue, "issue", "i", "", "The URL of a repository to post the output as a new issue, or the URL of an issue to add a comment to that issue")

--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -10,6 +10,10 @@ var rootCmd = &cobra.Command{
 	Use:   "gh-slack [command]",
 	Short: "Command line tool for interacting with Slack through gh cli",
 	Long:  `A command line tool for interacting with Slack through the gh cli.`,
+	Example: `  gh-slack -i <issue-url> <slack-permalink>  # defaults to read command
+  gh-slack read <slack-permalink>
+  gh-slack read -i <issue-url> <slack-permalink>
+  gh-slack send -m <message> -c <channel-id> -t <team-name>`,
 }
 
 func Execute() error {

--- a/cmd/gh-slack/cmd/send.go
+++ b/cmd/gh-slack/cmd/send.go
@@ -2,16 +2,92 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"os"
 
+	"github.com/rneatherway/gh-slack/internal/slackclient"
 	"github.com/spf13/cobra"
 )
 
 var sendCmd = &cobra.Command{
-	Use:   "send",
+	Use:   "send [flags]",
 	Short: "Sends a message to a Slack channel",
 	Long:  `Sends a message to a Slack channel.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("send called")
-		return nil
+		channelID, err := cmd.Flags().GetString("channel")
+		if err != nil {
+			return err
+		}
+		message, err := cmd.Flags().GetString("message")
+		if err != nil {
+			return err
+		}
+		team, err := cmd.Flags().GetString("team")
+		if err != nil {
+			return err
+		}
+		logger := log.New(io.Discard, "", log.LstdFlags)
+		if verbose {
+			logger = log.Default()
+		}
+		return sendMessage(team, channelID, message, logger)
 	},
+	Example: `  gh-slack send -t <team-name> -c <channel-id> -m <message>`,
 }
+
+// sendMessage sends a message to a Slack channel.
+func sendMessage(team, channelID, message string, logger *log.Logger) error {
+	client, err := slackclient.New(team, logger)
+	if err != nil {
+		return err
+	}
+	resp, err := client.SendMessage(channelID, message)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, resp.Output(team, channelID))
+	return nil
+}
+
+func init() {
+	sendCmd.Flags().StringP("channel", "c", "", "Channel ID to send the message to (required)")
+	sendCmd.Flags().StringP("message", "m", "", "Message to send (required)")
+	sendCmd.Flags().StringP("team", "t", "", "Slack team name (required)")
+	sendCmd.MarkFlagRequired("channel")
+	sendCmd.MarkFlagRequired("message")
+	sendCmd.MarkFlagRequired("team")
+	sendCmd.MarkFlagsRequiredTogether("channel", "message", "team")
+	sendCmd.SetUsageTemplate(sendCmdUsage)
+	sendCmd.SetHelpTemplate(sendCmdUsage)
+}
+
+const sendCmdUsage string = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}}{{end}}{{if gt (len .Aliases) 0}}
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -1,6 +1,7 @@
 package slackclient
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -34,6 +36,28 @@ type Message struct {
 	Attachments []Attachment
 	Ts          string
 	Type        string
+}
+
+type SendMessage struct {
+	ThreadTS    string       `json:"thread_ts,omitempty"`
+	Channel     string       `json:"channel"` // required
+	Text        string       `json:"text,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+}
+
+type SendMessageResponse struct {
+	OK      bool    `json:"ok"`
+	Error   string  `json:"error,omitempty"`
+	Warning string  `json:"warning,omitempty"`
+	TS      string  `json:"ts,omitempty"`
+	Message Message `json:"message,omitempty"`
+}
+
+func (r *SendMessageResponse) Output(team, channelID string) string {
+	if !r.OK {
+		return fmt.Sprintf("Error: %s", r.Error)
+	}
+	return fmt.Sprintf("Message permalink https://%s.slack.com/archives/%s/p%s", team, channelID, strings.ReplaceAll(r.TS, ".", ""))
 }
 
 type HistoryResponse struct {
@@ -130,6 +154,64 @@ func (c *SlackClient) get(path string, params map[string]string) ([]byte, error)
 		if err != nil {
 			return nil, err
 		}
+		for key := range c.auth.Cookies {
+			req.AddCookie(&http.Cookie{Name: key, Value: c.auth.Cookies[key]})
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == 429 {
+			s, err := strconv.Atoi(resp.Header["Retry-After"][0])
+			if err != nil {
+				return nil, err
+			}
+			d := time.Duration(s)
+			c.log.Printf("rate limited, waiting %ds", d)
+			time.Sleep(d * time.Second)
+		} else if resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("status code %d, headers: %q, body: %q", resp.StatusCode, resp.Header, body)
+		} else {
+			break
+		}
+	}
+
+	return body, nil
+}
+
+func (c *SlackClient) post(path string, params map[string]string, msg *SendMessage) ([]byte, error) {
+	u, err := url.Parse(fmt.Sprintf("https://%s.slack.com/api/", c.team))
+	if err != nil {
+		return nil, err
+	}
+	u.Path += path
+	q := u.Query()
+	for p := range params {
+		q.Add(p, params[p])
+	}
+	u.RawQuery = q.Encode()
+
+	var body []byte
+	messageBytes, err := json.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal message: %w", err)
+	}
+	reqBody := bytes.NewReader(messageBytes)
+
+	for {
+		req, err := http.NewRequest(http.MethodPost, u.String(), reqBody)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.auth.Token))
 		for key := range c.auth.Cookies {
 			req.AddCookie(&http.Cookie{Name: key, Value: c.auth.Cookies[key]})
 		}
@@ -367,4 +449,27 @@ func (c *SlackClient) UsernameForID(id string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no user with id %q", id)
+}
+
+func (c *SlackClient) SendMessage(channelID string, message string) (*SendMessageResponse, error) {
+	body, err := c.post("chat.postMessage",
+		map[string]string{}, &SendMessage{
+			Channel: channelID,
+			Text:    message,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SendMessageResponse{}
+	err = json.Unmarshal(body, response)
+	if err != nil {
+		return nil, err
+	}
+
+	if !response.OK {
+		return nil, fmt.Errorf("chat.postMessage response not OK: %s", body)
+	}
+
+	return response, nil
 }


### PR DESCRIPTION
In this PR we hook up the send subcommand to send message on slack using the channel id, team name, and message. This is in favour of the other PR where we add the `WriteMessage` method on the `slackclient`.