### PR TITLE
Add testing to slackclient for write operations

### DIFF
--- a/cmd/gh-slack/cmd/read.go
+++ b/cmd/gh-slack/cmd/read.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -113,9 +114,12 @@ func readSlack(args []string) error {
 		logger = log.Default()
 	}
 
-	client, err := slackclient.New(
-		linkParts.team,
-		logger)
+	httpClient := http.Client{}
+	auth, err := slackclient.GetSlackAuth(linkParts.team)
+	if err != nil {
+		return err
+	}
+	client, err := slackclient.New(linkParts.team, logger, &httpClient, auth)
 	if err != nil {
 		return err
 	}

--- a/cmd/gh-slack/cmd/send.go
+++ b/cmd/gh-slack/cmd/send.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/rneatherway/gh-slack/internal/slackclient"
@@ -38,7 +39,12 @@ var sendCmd = &cobra.Command{
 
 // sendMessage sends a message to a Slack channel.
 func sendMessage(team, channelID, message string, logger *log.Logger) error {
-	client, err := slackclient.New(team, logger)
+	httpClient := http.Client{}
+	auth, err := slackclient.GetSlackAuth(team)
+	if err != nil {
+		return err
+	}
+	client, err := slackclient.New(team, logger, &httpClient, auth)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require (
 	github.com/billgraziano/dpapi v0.4.0
 	github.com/cli/go-gh v0.0.3
-	github.com/jessevdk/go-flags v1.5.0
 	github.com/keybase/go-keychain v0.0.0-20220506172723-c18928ccd7f2
 	github.com/spf13/cobra v1.6.1
+	github.com/tjgurwara99/mixtape v0.0.5
 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122
 	modernc.org/sqlite v1.15.3
 	r00t2.io/gosecret v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/henvic/httpretty v0.0.6 h1:JdzGzKZBajBfnvlMALXXMVQWxWMF/ofTy8C3/OSUTx
 github.com/henvic/httpretty v0.0.6/go.mod h1:X38wLjWXHkXT7r2+uK8LjCMne9rsuNaBLJ+5cU2/Pmo=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
-github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/keybase/go-keychain v0.0.0-20220506172723-c18928ccd7f2 h1:Qh9gCBYNeGqpMv7SMVGgansYlZgnMkuPOQZpoZNxSJs=
@@ -53,6 +51,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tjgurwara99/mixtape v0.0.5 h1:fsnM37+gVmHh/v5m7hWIXT3HSZOwp9RMmqcBwjdDkfc=
+github.com/tjgurwara99/mixtape v0.0.5/go.mod h1:rWb4gvSbZQMsyG+5bsnuffPckEk+PkRhkC/fXmwmYZY=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -75,7 +75,6 @@ golang.org/x/sys v0.0.0-20200828161417-c663848e9a16/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201126233918-771906719818/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210902050250-f475640dd07b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -102,13 +102,13 @@ type Cache struct {
 type SlackClient struct {
 	cachePath string
 	team      string
-	client    http.Client
+	client    *http.Client
 	auth      *SlackAuth
 	cache     Cache
 	log       *log.Logger
 }
 
-func New(team string, log *log.Logger) (*SlackClient, error) {
+func New(team string, log *log.Logger, client *http.Client, auth *SlackAuth) (*SlackClient, error) {
 	dataHome := os.Getenv("XDG_DATA_HOME")
 	if dataHome == "" {
 		home, err := os.UserHomeDir()
@@ -119,19 +119,15 @@ func New(team string, log *log.Logger) (*SlackClient, error) {
 	}
 	cachePath := path.Join(dataHome, "gh-slack")
 
-	auth, err := getSlackAuth(team)
-	if err != nil {
-		return nil, err
-	}
-
 	c := &SlackClient{
 		cachePath: cachePath,
 		team:      team,
 		auth:      auth,
+		client:    client,
 		log:       log,
 	}
 
-	err = c.loadCache()
+	err := c.loadCache()
 	return c, err
 }
 

--- a/internal/slackclient/client_test.go
+++ b/internal/slackclient/client_test.go
@@ -1,0 +1,45 @@
+package slackclient_test
+
+import (
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/rneatherway/gh-slack/internal/slackclient"
+	"github.com/tjgurwara99/mixtape"
+	"github.com/tjgurwara99/mixtape/player"
+)
+
+func compareFuncWithBodyAndAuth(r *http.Request, recording *mixtape.Request) bool {
+	if !mixtape.CompareFuncWithBody(r, recording) {
+		return false
+	}
+	if r.Header.Get("Authorization") != recording.Header.Get("Authorization") {
+		return false
+	}
+	return true
+}
+
+func TestWriteMessage(t *testing.T) {
+	cassette, err := mixtape.Load("testdata/write_message")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cassette.Comparer = compareFuncWithBodyAndAuth
+	cassetteTranport := player.New(cassette, player.Replay, http.DefaultTransport)
+	httpClient := &http.Client{
+		Transport: cassetteTranport,
+	}
+	auth := &slackclient.SlackAuth{
+		Token: "abc123",
+	}
+	client, err := slackclient.New("github", log.Default(), httpClient, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.SendMessage("C04QJSB8G4D", "Sending a message from test to mock http interactions")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/slackclient/testdata/write_message.json
+++ b/internal/slackclient/testdata/write_message.json
@@ -1,0 +1,54 @@
+{
+  "songs": [
+    {
+      "id": 0,
+      "request": {
+        "Method": "POST",
+        "URL": "https://github.slack.com/api/chat.postMessage",
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Authorization": [
+            "Bearer abc123"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Cookie": [
+            "blahblahblah"
+          ]
+        },
+        "Body": "{\"channel\":\"C04QJSB8G4D\",\"text\":\"Sending a message from test to mock http interactions\"}",
+        "ContentLength": 88,
+        "TransferEncoding": null,
+        "Close": false,
+        "Host": "github.slack.com",
+        "Form": null,
+        "PostForm": null,
+        "MultipartForm": null,
+        "Trailer": null,
+        "RemoteAddr": "",
+        "RequestURI": "",
+        "TLS": null
+      },
+      "response": {
+        "Status": "200 OK",
+        "StatusCode": 200,
+        "Proto": "HTTP/2.0",
+        "ProtoMajor": 2,
+        "ProtoMinor": 0,
+        "Header": {
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ]
+        },
+        "Body": "{\"ok\":true,\"channel\":\"C04QJSB8G4D\",\"ts\":\"1677107538.722019\",\"message\":{\"type\":\"message\",\"text\":\"Sending a message from test to mock http interactions\",\"user\":\"U03RRATS2BA\",\"ts\":\"1677107538.722019\",\"blocks\":[{\"type\":\"rich_text\",\"block_id\":\"9BS1\",\"elements\":[{\"type\":\"rich_text_section\",\"elements\":[{\"type\":\"text\",\"text\":\"Sending a message from test to mock http interactions\"}]}]}],\"team\":\"T0CA8C346\"}}",
+        "ContentLength": -1,
+        "TransferEncoding": null,
+        "Close": false,
+        "Trailer": null
+      }
+    }
+  ]
+}

--- a/internal/slackclient/token.go
+++ b/internal/slackclient/token.go
@@ -93,7 +93,7 @@ func getCookie() (string, error) {
 
 var apiTokenRE = regexp.MustCompile("\"api_token\":\"([^\"]+)\"")
 
-func getSlackAuth(team string) (*SlackAuth, error) {
+func GetSlackAuth(team string) (*SlackAuth, error) {
 	cookie, err := getCookie()
 	if err != nil {
 		return nil, err

--- a/internal/slackclient/token_test.go
+++ b/internal/slackclient/token_test.go
@@ -19,7 +19,7 @@ func TestGetCookie(t *testing.T) {
 }
 
 func TestGetAuth(t *testing.T) {
-	auth, err := getSlackAuth("github")
+	auth, err := GetSlackAuth("github")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
In this PR we introduce a new package `github.com/tjgurwara99/mixtape` which is a package that I've been working on for the past few weeks. This package is very similar to the `go-vcr` package but I wanted to create a smaller package with only the required feature since the API exposure of `go-vcr` is quite big 😅 Anyhow, I can remove this and add the `go-vcr` package if there is some push.

Using this package we have added an ability for testing our slack requests without actually using the tcp connection over the internet and connecting to a real slack environment.