### PR TITLE
Adds plumbing for message events from the RTM API

### DIFF
--- a/cmd/gh-slack/cmd/read.go
+++ b/cmd/gh-slack/cmd/read.go
@@ -116,6 +116,7 @@ func readSlack(args []string) error {
 	client, err := slackclient.New(
 		linkParts.team,
 		logger)
+	defer client.Close()
 	if err != nil {
 		return err
 	}

--- a/cmd/gh-slack/cmd/send.go
+++ b/cmd/gh-slack/cmd/send.go
@@ -39,6 +39,7 @@ var sendCmd = &cobra.Command{
 // sendMessage sends a message to a Slack channel.
 func sendMessage(team, channelID, message string, logger *log.Logger) error {
 	client, err := slackclient.New(team, logger)
+	defer client.Close()
 	if err != nil {
 		return err
 	}

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -151,6 +151,14 @@ func New(team string, log *log.Logger) (*SlackClient, error) {
 	return c, err
 }
 
+func (c *SlackClient) Close() {
+	// If c.ws_conn is nil, we never established a websocket connection, so there's nothing to close.
+	if c.ws_conn == nil {
+		return
+	}
+	c.ws_conn.Close(websocket.StatusNormalClosure, "")
+}
+
 func (c *SlackClient) get(path string, params map[string]string) ([]byte, error) {
 	u, err := url.Parse(fmt.Sprintf("https://%s.slack.com/api/", c.team))
 	if err != nil {

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -534,3 +534,23 @@ func (c *SlackClient) SendMessage(channelID string, message string) (*SendMessag
 
 	return response, nil
 }
+
+// TODO: Stub implementation of listening for messages
+func (c *SlackClient) ListenForMessages() error {
+	fmt.Println("=== Reading from websocket connection... ===")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	for i := 0; i < 5; i++ {
+		ws_message := &RTMEvent{}
+		err := wsjson.Read(ctx, c.ws_conn, ws_message)
+		if err != nil {
+			c.ws_conn.Close(websocket.StatusUnsupportedData, "")
+			return err
+		}
+		fmt.Println("=== Received ===")
+		fmt.Println(ws_message)
+	}
+	fmt.Println("=== Done Reading ===")
+	return nil
+}

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -2,6 +2,7 @@ package slackclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
 )
 
 type Cursor struct {
@@ -148,6 +150,41 @@ func New(team string, log *log.Logger) (*SlackClient, error) {
 	}
 
 	err = c.loadCache()
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.get("rtm.connect",
+		map[string]string{})
+	if err != nil {
+		// The call to rtm.connect failed, so we can't establish a websocket connection.
+		// TODO: If we're attempting to execute a Send subcommand, throw an error and exit
+		// since we won't be able to receive responses to messages we send.
+		return c, err
+	}
+	connect_response := &RTMConnectResponse{}
+	err = json.Unmarshal(response, connect_response)
+	if err != nil {
+		// We were unable to unmarshal the response from rtm.connect, so we can't establish a websocket connection.
+		// TODO: If we're attempting to execute a Send subcommand, throw an error and exit
+		// since we won't be able to receive responses to messages we send.
+		return c, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	socket_connection, _, err := websocket.Dial(ctx, connect_response.URL, &websocket.DialOptions{})
+	if err != nil {
+		// We were unable to establish a websocket connection.
+		// TODO: If we're attempting to execute a Send subcommand, throw an error and exit
+		// since we won't be able to receive responses to messages we send.
+		return c, err
+	}
+	c.ws_conn = socket_connection
+	// TODO: We should consider saving connect_response.URL to the cache:
+	// 1. rtm.connect is a Tier 1 Slack API, which means we're allowed about 1 call per minute. Short bursts are tolerated, but discouraged.
+	// 2. If we save connect_response.URL to the cache, we can avoid calling rtm.connect on every invocation of gh-slack.
+	// We'll then need to add additional logic here to "Dial" the cached wss URL, and if it fails, only then call rtm.connect.
+	// If we do this, we'll also need to remove calls to "c.ws_conn.Close" _unless_ there is an error. This way we keep the connection alive.
 	return c, err
 }
 

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -53,6 +53,11 @@ type SendMessageResponse struct {
 	Message Message `json:"message,omitempty"`
 }
 
+type RTMConnectResponse struct {
+	Ok  bool   `json:"ok"`
+	URL string `json:"url"`
+}
+
 type RTMEvent struct {
 	Type    string `json:"type"`
 	Channel string `json:"channel,omitempty"`

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"nhooyr.io/websocket"
 )
 
 type Cursor struct {
@@ -119,6 +121,7 @@ type SlackClient struct {
 	auth      *SlackAuth
 	cache     Cache
 	log       *log.Logger
+	ws_conn   *websocket.Conn
 }
 
 func New(team string, log *log.Logger) (*SlackClient, error) {

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -53,6 +53,14 @@ type SendMessageResponse struct {
 	Message Message `json:"message,omitempty"`
 }
 
+type RTMEvent struct {
+	Type    string `json:"type"`
+	Channel string `json:"channel,omitempty"`
+	User    string `json:"user,omitempty"`
+	Text    string `json:"text,omitempty"`
+	TS      string `json:"ts,omitempty"`
+}
+
 func (r *SendMessageResponse) Output(team, channelID string) string {
 	if !r.OK {
 		return fmt.Sprintf("Error: %s", r.Error)


### PR DESCRIPTION
This PR adds:

- A new dependency to `nhooyr.io/websocket` (https://pkg.go.dev/nhooyr.io/websocket)
- Some plumbing to connect to the Slack `rtm.connect` API (https://api.slack.com/rtm)
- Some minor changes to the SlackClient including:
  - A `Close` method to be called whenever a `SlackClient` instance is going out of scope. This allows us to do things like close websocket connections
  - A `ws_conn` member on the `SlackClient` to hold on to an instance of a `websocket.Conn`
- A temporary / placeholder method on the `SlackClient` called `ListenForMessages` that simply listens for events coming on the Slack RTM API, until 5 events have been received. 

💡 ~ Try modifying `client.go` to call `ListenForMessages()` at the end of `SendMessage()` and observe what happens. 

🧠 If you want to understand the changes, I would suggest reviewing this PR one commit at a time, in the order of commits.