### PR TITLE
Move differred cleanup after err check

### DIFF
--- a/cmd/gh-slack/cmd/read.go
+++ b/cmd/gh-slack/cmd/read.go
@@ -113,13 +113,11 @@ func readSlack(args []string) error {
 		logger = log.Default()
 	}
 
-	client, err := slackclient.New(
-		linkParts.team,
-		logger)
-	defer client.Close()
+	client, err := slackclient.New(linkParts.team, logger)
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	history, err := client.History(linkParts.channelID, linkParts.timestamp, opts.Limit)
 	if err != nil {


### PR DESCRIPTION
Moved differed cleanup in the read subcommand after error check block.